### PR TITLE
Add Posix Quoting Support

### DIFF
--- a/src/pch.hpp
+++ b/src/pch.hpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
@@ -11,6 +12,7 @@
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <stack>
 #include <string>
 #include <variant>
 #include <vector>

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -133,7 +133,7 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
                 }else if(chr == INPUT_REDIRECTION){ // transition to input filename
                     add_current_arg(); // the redirection characters will act like whitespace
                     curr_state.push(PARSE_STATE::INPUT_FILENAME);
-                }else if(chr == OUTPUT_FILENAME){ // transition to output filename
+                }else if(chr == OUTPUT_REDIRECTION){ // transition to output filename
                     add_current_arg(); // the redirection characters will act like whitespace
                     curr_state.push(PARSE_STATE::OUTPUT_FILENAME);
                 }else if(chr == SINGLE_QUOTE){ // transition to single quote state
@@ -237,6 +237,8 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
         cout_logger.log(LOG_LEVEL::ERROR, "No filename provided...");
         return std::nullopt;
     }
+
+    // create leftover filenames
     if(curr_state.top() == PARSE_STATE::INPUT_FILENAME && !arg.empty()){
         proc_stdin = syscall_wrapper::open_wrapper(arg, O_RDONLY, FILE_MODE);
 
@@ -247,7 +249,7 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
     if(curr_state.top() == PARSE_STATE::OUTPUT_FILENAME && !arg.empty()){
         proc_stdout = syscall_wrapper::open_wrapper(arg, O_WRONLY | O_CREAT | O_TRUNC, FILE_MODE);
 
-        if (!proc_stdin.has_value()) {
+        if (!proc_stdout.has_value()) {
             return std::nullopt;
         }
     }

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -140,6 +140,8 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
                     curr_state.push(PARSE_STATE::QUOTE);
                 }else if(chr == DOUBLE_QUOTE){ // transition to double quote state
                     curr_state.push(PARSE_STATE::DBL_QUOTE);
+                }else if(chr == ESCAPE){ // if we encounter a a backslash escape next char
+                    curr_state.push(PARSE_STATE::ESCAPED_CHARACTER);
                 }else{ // append the character
                     arg += chr;
                 }
@@ -170,6 +172,8 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
                     curr_state.push(PARSE_STATE::QUOTE);
                 }else if(chr == DOUBLE_QUOTE){ // transition to double quote state
                     curr_state.push(PARSE_STATE::DBL_QUOTE);
+                }else if(chr == ESCAPE){ // if we encounter a a backslash escape next char
+                    curr_state.push(PARSE_STATE::ESCAPED_CHARACTER);
                 }else{ // append the character
                     arg += chr;
                 }
@@ -199,6 +203,8 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
                     curr_state.push(PARSE_STATE::QUOTE);
                 }else if(chr == DOUBLE_QUOTE){ // transition to double quote state
                     curr_state.push(PARSE_STATE::DBL_QUOTE);
+                }else if(chr == ESCAPE){ // if we encounter a a backslash escape next char
+                    curr_state.push(PARSE_STATE::ESCAPED_CHARACTER);
                 }else{ // append the character
                     arg += chr;
                 }
@@ -207,6 +213,8 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
             case PARSE_STATE::QUOTE:{
                 if(chr == SINGLE_QUOTE){ // close single quote
                     curr_state.pop();
+                }else if(chr == ESCAPE){ // if we encounter a a backslash escape next char
+                    curr_state.push(PARSE_STATE::ESCAPED_CHARACTER);
                 }else{ // append the character
                     arg += chr;
                 }
@@ -215,9 +223,17 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
             case PARSE_STATE::DBL_QUOTE:{
                 if(chr == DOUBLE_QUOTE){ // close double quote
                     curr_state.pop();
+                }else if(chr == ESCAPE){ // if we encounter a a backslash escape next char
+                    curr_state.push(PARSE_STATE::ESCAPED_CHARACTER);
                 }else{ // append the character
                     arg += chr;
                 }
+                break;
+            }
+            case PARSE_STATE::ESCAPED_CHARACTER:{
+                // add the character to the argument
+                arg += chr;
+                curr_state.pop();
                 break;
             }
             case PARSE_STATE::COUNT:{
@@ -229,8 +245,8 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
     }
 
     // check to make sure for errors
-    if(curr_state.top() == PARSE_STATE::QUOTE || curr_state.top() == PARSE_STATE::DBL_QUOTE){
-        cout_logger.log(LOG_LEVEL::ERROR, "Invalid process input, unclosed quotation...");
+    if(curr_state.top() == PARSE_STATE::QUOTE || curr_state.top() == PARSE_STATE::DBL_QUOTE || curr_state.top() == PARSE_STATE::ESCAPED_CHARACTER){
+        cout_logger.log(LOG_LEVEL::ERROR, "Invalid process input...");
         return std::nullopt;
     }
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -233,6 +233,7 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
         cout_logger.log(LOG_LEVEL::ERROR, "Invalid process input, unclosed quotation...");
         return std::nullopt;
     }
+
     if((curr_state.top() == PARSE_STATE::OUTPUT_FILENAME || curr_state.top() == PARSE_STATE::INPUT_FILENAME) && arg.empty()){
         cout_logger.log(LOG_LEVEL::ERROR, "No filename provided...");
         return std::nullopt;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -245,13 +245,18 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
         if (!proc_stdin.has_value()) {
             return std::nullopt;
         }
+
+        arg.clear();
     }
+
     if(curr_state.top() == PARSE_STATE::OUTPUT_FILENAME && !arg.empty()){
         proc_stdout = syscall_wrapper::open_wrapper(arg, O_WRONLY | O_CREAT | O_TRUNC, FILE_MODE);
 
         if (!proc_stdout.has_value()) {
             return std::nullopt;
         }
+
+        arg.clear();
     }
 
     // add any leftover arguments
@@ -280,7 +285,7 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
             cout_logger.log(LOG_LEVEL::DEBUG, "Export arg: ", argument);
         }
 
-        if (args.size() != 2) {
+        if (args.size() < 2) {
             return std::nullopt;
         }
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -115,7 +115,7 @@ auto process::parse_process(std::string const& input) -> std::optional<std::uniq
     std::stack<PARSE_STATE> curr_state{};
     // default behavior should be REGULAR mode
     curr_state.push(PARSE_STATE::REGULAR);
-    for (char chr : input) {
+    for (char const chr : input) {
         assert(!curr_state.empty()); // this should be true since we dont pop in REGULAR
         assert(static_cast<char>(curr_state.top()) < PARSE_STATE::COUNT);
 

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -65,11 +65,25 @@ class process {
     static constexpr char EQUALS = '=';
     static constexpr char INPUT_REDIRECTION = '<';
     static constexpr char OUTPUT_REDIRECTION = '>';
+    static constexpr char SINGLE_QUOTE = '\'';
+    static constexpr char DOUBLE_QUOTE = '\"';
 
     /**
      * populate the binary with its data
      */
     static void populate_process_data(binary_data& data);
+
+    /**
+     * parse_state: the current state of the parsing algorithm
+     */
+    enum PARSE_STATE : char {
+        REGULAR = 0,
+        QUOTE = 1,
+        DBL_QUOTE = 2,
+        INPUT_FILENAME = 3,
+        OUTPUT_FILENAME = 4,
+        COUNT = 5
+    };
 
     /**
      * shell_internal_redirection: RAII wrapper around setting stdout, stdin, and stderr for a given shell internal

--- a/src/process.hpp
+++ b/src/process.hpp
@@ -67,6 +67,7 @@ class process {
     static constexpr char OUTPUT_REDIRECTION = '>';
     static constexpr char SINGLE_QUOTE = '\'';
     static constexpr char DOUBLE_QUOTE = '\"';
+    static constexpr char ESCAPE = '\\';
 
     /**
      * populate the binary with its data
@@ -82,7 +83,8 @@ class process {
         DBL_QUOTE = 2,
         INPUT_FILENAME = 3,
         OUTPUT_FILENAME = 4,
-        COUNT = 5
+        ESCAPED_CHARACTER = 5,
+        COUNT = 6
     };
 
     /**

--- a/testing/test_environment.cpp
+++ b/testing/test_environment.cpp
@@ -6,6 +6,7 @@
 #include <macros.hpp>
 
 TEST(TestEnvironment, EnvironmentSetGet) {
+    jsh::set_log_level(jsh::LOG_LEVEL::DEBUG);
     // create the envp
     std::string var1 = "VAR1", var2 = "VAR2", var3 = "VAR3", var4 = "VAR4"; // NOLINT
     std::string val1 = "VAL1", val2 = "VAL2", val3 = "VAL3", val4 = "VAL4"; // NOLINT

--- a/testing/test_process.cpp
+++ b/testing/test_process.cpp
@@ -561,7 +561,7 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenamesEsacpe1) {
 }
 
 TEST(TestProcess, TestPosixNestedQuotesAndFilenamesEscape2) {
-    std::string const input = R"(echo a"'awda'a"r >testing/tmp/\>> testing/tmp/"adjwojo"a)";
+    std::string const input = R"(echo a"'awda'a"r >testing/tmp/\>> testing/tmp/"adj\>wo>jo"a)";
     std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
 
     auto proc_data = jsh::process::parse_process(input);

--- a/testing/test_process.cpp
+++ b/testing/test_process.cpp
@@ -330,10 +330,10 @@ TEST(TestProcess, TestPosixNestedQuotes1) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -347,10 +347,10 @@ TEST(TestProcess, TestPosixNestedQuotes2) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -364,10 +364,10 @@ TEST(TestProcess, TestPosixNestedQuotes3) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -381,10 +381,10 @@ TEST(TestProcess, TestPosixAdjacentQuotes1) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -398,10 +398,10 @@ TEST(TestProcess, TestPosixAdjacentQuotes2) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -415,10 +415,10 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenames1) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -432,10 +432,10 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenames2) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -449,10 +449,10 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenames3) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -466,10 +466,10 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenames4) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -501,10 +501,10 @@ TEST(TestProcess, TestPosixNestedQuotesEscape1) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -518,10 +518,10 @@ TEST(TestProcess, TestPosixNestedQuotesEscape2) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -535,10 +535,10 @@ TEST(TestProcess, TestPosixNestedQuotesEscape3) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -552,10 +552,10 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenamesEsacpe1) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }
@@ -569,10 +569,10 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenamesEscape2) {
     // make sure the command was invalid
     ASSERT_TRUE(proc_data.has_value());
     ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value());               // NOLINT assert catches this .value()
 
     // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
+    for (std::size_t i = 0; i < correct.size(); ++i) {
         ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
     }
 }

--- a/testing/test_process.cpp
+++ b/testing/test_process.cpp
@@ -320,3 +320,166 @@ TEST(TestProcess, TestOutputRedirectionParsingMalformed2) {
     // make sure the command was invalid
     ASSERT_FALSE(proc_data.has_value());
 }
+
+TEST(TestProcess, TestPosixNestedQuotes1) {
+    std::string const input = R"(echo "a'awda'a")";
+    std::vector<std::string> correct{"echo", R"(a'awda'a)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotes2) {
+    std::string const input = R"(echo "a'awda'")";
+    std::vector<std::string> correct{"echo", R"(a'awda')"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotes3) {
+    std::string const input = R"(echo "'awda'a")";
+    std::vector<std::string> correct{"echo", R"('awda'a)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixAdjacentQuotes1) {
+    std::string const input = R"(echo a"'awda'a"a)";
+    std::vector<std::string> correct{"echo", R"(a'awda'aa)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixAdjacentQuotes2) {
+    std::string const input = R"(echo a"'awda'a"r)";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotesAndFilenames1) {
+    std::string const input = R"(echo a"'awda'a"r > apwodpk"adjwojo"a)";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotesAndFilenames2) {
+    std::string const input = R"(echo a"'awda'a"r >>> "adjwojo"a)";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotesAndFilenames3) {
+    std::string const input = R"(echo a"'awda'a"r >>> adwad"adjwojo")";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotesAndFilenames4) {
+    std::string const input = R"(echo a"'awda'a"r >>> "adjwojo")";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixFilenameMalformed) {
+    std::string const input = R"(echo a"'awda'a"r >>>)";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_FALSE(proc_data.has_value());
+}

--- a/testing/test_process.cpp
+++ b/testing/test_process.cpp
@@ -476,10 +476,171 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenames4) {
 
 TEST(TestProcess, TestPosixFilenameMalformed) {
     std::string const input = R"(echo a"'awda'a"r >>>)";
-    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
 
     auto proc_data = jsh::process::parse_process(input);
 
     // make sure the command was invalid
     ASSERT_FALSE(proc_data.has_value());
+}
+
+TEST(TestProcess, TestPosixUnclosedEscape) {
+    std::string const input = R"(echo a"'awda'a"r\)";
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_FALSE(proc_data.has_value());
+}
+
+TEST(TestProcess, TestPosixNestedQuotesEscape1) {
+    std::string const input = R"(echo "a'awda'a")";
+    std::vector<std::string> correct{"echo", R"(a'awda'a)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotes2) {
+    std::string const input = R"(echo "a'awda'")";
+    std::vector<std::string> correct{"echo", R"(a'awda')"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotes3) {
+    std::string const input = R"(echo "'awda'a")";
+    std::vector<std::string> correct{"echo", R"('awda'a)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixAdjacentQuotes1) {
+    std::string const input = R"(echo a"'awda'a"a)";
+    std::vector<std::string> correct{"echo", R"(a'awda'aa)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixAdjacentQuotes2) {
+    std::string const input = R"(echo a"'awda'a"r)";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotesAndFilenames1) {
+    std::string const input = R"(echo a"'awda'a"r > apwodpk"adjwojo"a)";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotesAndFilenames2) {
+    std::string const input = R"(echo a"'awda'a"r >>> "adjwojo"a)";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotesAndFilenames3) {
+    std::string const input = R"(echo a"'awda'a"r >>> adwad"adjwojo")";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
+}
+
+TEST(TestProcess, TestPosixNestedQuotesAndFilenames4) {
+    std::string const input = R"(echo a"'awda'a"r >>> "adjwojo")";
+    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
+
+    auto proc_data = jsh::process::parse_process(input);
+
+    // make sure the command was invalid
+    ASSERT_TRUE(proc_data.has_value());
+    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
+    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
+
+    // compare the arguments
+    for(std::size_t i = 0; i < correct.size(); ++i){
+        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
+    }
 }

--- a/testing/test_process.cpp
+++ b/testing/test_process.cpp
@@ -407,7 +407,7 @@ TEST(TestProcess, TestPosixAdjacentQuotes2) {
 }
 
 TEST(TestProcess, TestPosixNestedQuotesAndFilenames1) {
-    std::string const input = R"(echo a"'awda'a"r > apwodpk"adjwojo"a)";
+    std::string const input = R"(echo a"'awda'a"r > testing/tmp/apwodpk"adjwojo"a)";
     std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
 
     auto proc_data = jsh::process::parse_process(input);
@@ -424,7 +424,7 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenames1) {
 }
 
 TEST(TestProcess, TestPosixNestedQuotesAndFilenames2) {
-    std::string const input = R"(echo a"'awda'a"r >>> "adjwojo"a)";
+    std::string const input = R"(echo a"'awda'a"r >>> "testing/tmp/adjwojo"a)";
     std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
 
     auto proc_data = jsh::process::parse_process(input);
@@ -441,7 +441,7 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenames2) {
 }
 
 TEST(TestProcess, TestPosixNestedQuotesAndFilenames3) {
-    std::string const input = R"(echo a"'awda'a"r >>> adwad"adjwojo")";
+    std::string const input = R"(echo a"'awda'a"r >>> testing/tmp/adwad"adjwojo")";
     std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
 
     auto proc_data = jsh::process::parse_process(input);
@@ -458,7 +458,7 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenames3) {
 }
 
 TEST(TestProcess, TestPosixNestedQuotesAndFilenames4) {
-    std::string const input = R"(echo a"'awda'a"r >>> "adjwojo")";
+    std::string const input = R"(echo a"'awda'a"r >>> testing/tmp/"adjwojo")";
     std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
 
     auto proc_data = jsh::process::parse_process(input);
@@ -493,8 +493,8 @@ TEST(TestProcess, TestPosixUnclosedEscape) {
 }
 
 TEST(TestProcess, TestPosixNestedQuotesEscape1) {
-    std::string const input = R"(echo "a'awda'a")";
-    std::vector<std::string> correct{"echo", R"(a'awda'a)"};
+    std::string const input = R"(echo "a\"\'aw\da'a")";
+    std::vector<std::string> correct{"echo", R"(a"'awda'a)"};
 
     auto proc_data = jsh::process::parse_process(input);
 
@@ -509,9 +509,9 @@ TEST(TestProcess, TestPosixNestedQuotesEscape1) {
     }
 }
 
-TEST(TestProcess, TestPosixNestedQuotes2) {
-    std::string const input = R"(echo "a'awda'")";
-    std::vector<std::string> correct{"echo", R"(a'awda')"};
+TEST(TestProcess, TestPosixNestedQuotesEscape2) {
+    std::string const input = R"(echo\"\  "a'awda'")";
+    std::vector<std::string> correct{R"(echo" )", R"(a'awda')"};
 
     auto proc_data = jsh::process::parse_process(input);
 
@@ -526,9 +526,9 @@ TEST(TestProcess, TestPosixNestedQuotes2) {
     }
 }
 
-TEST(TestProcess, TestPosixNestedQuotes3) {
-    std::string const input = R"(echo "'awda'a")";
-    std::vector<std::string> correct{"echo", R"('awda'a)"};
+TEST(TestProcess, TestPosixNestedQuotesEscape3) {
+    std::string const input = R"(echo "'a\\wda'a\\")";
+    std::vector<std::string> correct{"echo", R"('a\wda'a\)"};
 
     auto proc_data = jsh::process::parse_process(input);
 
@@ -543,9 +543,9 @@ TEST(TestProcess, TestPosixNestedQuotes3) {
     }
 }
 
-TEST(TestProcess, TestPosixAdjacentQuotes1) {
-    std::string const input = R"(echo a"'awda'a"a)";
-    std::vector<std::string> correct{"echo", R"(a'awda'aa)"};
+TEST(TestProcess, TestPosixNestedQuotesAndFilenamesEsacpe1) {
+    std::string const input = R"(echo a"'awda'a\>"r > testing/tmp/apwodpk\"adjwojo\"a\>)";
+    std::vector<std::string> correct{"echo", R"(a'awda'a>r)"};
 
     auto proc_data = jsh::process::parse_process(input);
 
@@ -560,76 +560,8 @@ TEST(TestProcess, TestPosixAdjacentQuotes1) {
     }
 }
 
-TEST(TestProcess, TestPosixAdjacentQuotes2) {
-    std::string const input = R"(echo a"'awda'a"r)";
-    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
-
-    auto proc_data = jsh::process::parse_process(input);
-
-    // make sure the command was invalid
-    ASSERT_TRUE(proc_data.has_value());
-    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
-
-    // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
-        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
-    }
-}
-
-TEST(TestProcess, TestPosixNestedQuotesAndFilenames1) {
-    std::string const input = R"(echo a"'awda'a"r > apwodpk"adjwojo"a)";
-    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
-
-    auto proc_data = jsh::process::parse_process(input);
-
-    // make sure the command was invalid
-    ASSERT_TRUE(proc_data.has_value());
-    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
-
-    // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
-        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
-    }
-}
-
-TEST(TestProcess, TestPosixNestedQuotesAndFilenames2) {
-    std::string const input = R"(echo a"'awda'a"r >>> "adjwojo"a)";
-    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
-
-    auto proc_data = jsh::process::parse_process(input);
-
-    // make sure the command was invalid
-    ASSERT_TRUE(proc_data.has_value());
-    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
-
-    // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
-        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
-    }
-}
-
-TEST(TestProcess, TestPosixNestedQuotesAndFilenames3) {
-    std::string const input = R"(echo a"'awda'a"r >>> adwad"adjwojo")";
-    std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
-
-    auto proc_data = jsh::process::parse_process(input);
-
-    // make sure the command was invalid
-    ASSERT_TRUE(proc_data.has_value());
-    ASSERT_TRUE(std::holds_alternative<jsh::binary_data>(*proc_data.value())); // NOLINT assert catches this .value()
-    auto& data = std::get<jsh::binary_data>(*proc_data.value()); // NOLINT assert catches this .value()
-
-    // compare the arguments
-    for(std::size_t i = 0; i < correct.size(); ++i){
-        ASSERT_STREQ(correct[i].c_str(), data.args[i].c_str());
-    }
-}
-
-TEST(TestProcess, TestPosixNestedQuotesAndFilenames4) {
-    std::string const input = R"(echo a"'awda'a"r >>> "adjwojo")";
+TEST(TestProcess, TestPosixNestedQuotesAndFilenamesEscape2) {
+    std::string const input = R"(echo a"'awda'a"r >\>> testing/tmp/"adjwojo"a)";
     std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
 
     auto proc_data = jsh::process::parse_process(input);

--- a/testing/test_process.cpp
+++ b/testing/test_process.cpp
@@ -561,7 +561,7 @@ TEST(TestProcess, TestPosixNestedQuotesAndFilenamesEsacpe1) {
 }
 
 TEST(TestProcess, TestPosixNestedQuotesAndFilenamesEscape2) {
-    std::string const input = R"(echo a"'awda'a"r >\>> testing/tmp/"adjwojo"a)";
+    std::string const input = R"(echo a"'awda'a"r >testing/tmp/\>> testing/tmp/"adjwojo"a)";
     std::vector<std::string> correct{"echo", R"(a'awda'ar)"};
 
     auto proc_data = jsh::process::parse_process(input);


### PR DESCRIPTION
Quotes are supposed to be grouped together such that `git commit -m "message here"` creates the following c-strings in argv:
- `git`
- `commit`
- `-m`
- `message here`

Additionally, there should be handling not only for double quotes, but also single quotes.

Added support for escaped characters using `\`.